### PR TITLE
Reset password link for user #80

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
           set -x
           mkdir -p ./volumes/mattermost/{data,logs,config,plugins}
           sudo chown -R 2000:2000 ./volumes/mattermost/
+          docker volume create --name=postgres_database
           docker-compose up -d
      - run:
          name: Tests

--- a/node/controllers/passwordreset/index.js
+++ b/node/controllers/passwordreset/index.js
@@ -39,14 +39,15 @@ export const handlePasswordResetRequest = (req, res) => {
     })
 }
 
+// Non completed template for handling password reset
 export const handlePasswordReset = (req, res) => {
   const { uuid } = req.body
 
   PasswordResetUuid.findOne({ where: { uuid } })
     .then(passwordResetEntry => {
       // eslint-disable-next-line no-console
-      console.log(typeof passwordResetEntry.createdAt)
-
+      console.log(passwordResetEntry)
+      // Here check if the token is still valid, and change the password if so
       return res.status(200).send({
         success: true,
         message: 'Found',

--- a/node/controllers/passwordreset/index.js
+++ b/node/controllers/passwordreset/index.js
@@ -29,6 +29,7 @@ export const handlePasswordResetRequest = (req, res) => {
       return res.status(200).send({
         success: true,
         message: 'Email found!',
+        uuid,
       })
     })
     .catch(err => {

--- a/node/controllers/passwordreset/index.js
+++ b/node/controllers/passwordreset/index.js
@@ -3,7 +3,6 @@ import model from '../../models'
 
 const { PasswordResetUuid, User } = model
 
-// eslint-disable-next-line import/prefer-default-export
 export const handlePasswordResetRequest = (req, res) => {
   const { email } = req.body
 
@@ -26,16 +25,37 @@ export const handlePasswordResetRequest = (req, res) => {
       console.log('Created new database entry with uuid4 token')
       // eslint-disable-next-line no-console
       console.log(uuid)
-      return res.status(200).send({
+      return res.status(201).send({
         success: true,
         message: 'Email found and uuid generated and stored',
-        uuid,
       })
     })
     .catch(err => {
       return res.status(500).send({
         success: false,
         message: 'Email not found',
+        error: err,
+      })
+    })
+}
+
+export const handlePasswordReset = (req, res) => {
+  const { uuid } = req.body
+
+  PasswordResetUuid.findOne({ where: { uuid } })
+    .then(passwordResetEntry => {
+      // eslint-disable-next-line no-console
+      console.log(typeof passwordResetEntry.createdAt)
+
+      return res.status(200).send({
+        success: true,
+        message: 'Found',
+      })
+    })
+    .catch(err => {
+      return res.status(500).send({
+        success: false,
+        message: 'Given uuid does not match any stored uuids',
         error: err,
       })
     })

--- a/node/controllers/passwordreset/index.js
+++ b/node/controllers/passwordreset/index.js
@@ -28,7 +28,7 @@ export const handlePasswordResetRequest = (req, res) => {
       console.log(uuid)
       return res.status(200).send({
         success: true,
-        message: 'Email found!',
+        message: 'Email found and uuid generated and stored',
         uuid,
       })
     })

--- a/node/controllers/passwordreset/index.js
+++ b/node/controllers/passwordreset/index.js
@@ -1,0 +1,41 @@
+import uuidv4 from 'uuid/v4'
+import model from '../../models'
+
+const { PasswordResetUuid, User } = model
+
+// eslint-disable-next-line import/prefer-default-export
+export const handlePasswordResetRequest = (req, res) => {
+  const { email } = req.body
+
+  User.findOne({ where: { email } })
+    .then(user => {
+      const uuid = uuidv4()
+      PasswordResetUuid.create({ uuid, userId: user.id }).catch(err => {
+        // eslint-disable-next-line no-console
+        console.log(
+          'Something went wrong while creating database entry for new password reset token'
+        )
+        return res.status(500).send({
+          success: false,
+          message: 'Cannot create database entry',
+          error: err,
+        })
+      })
+
+      // eslint-disable-next-line no-console
+      console.log('Created new database entry with uuid4 token')
+      // eslint-disable-next-line no-console
+      console.log(uuid)
+      return res.status(200).send({
+        success: true,
+        message: 'Email found!',
+      })
+    })
+    .catch(err => {
+      return res.status(500).send({
+        success: false,
+        message: 'Email not found',
+        error: err,
+      })
+    })
+}

--- a/node/controllers/passwordreset/index.js
+++ b/node/controllers/passwordreset/index.js
@@ -1,4 +1,3 @@
-import uuidv4 from 'uuid/v4'
 import model from '../../models'
 
 const { PasswordResetUuid, User } = model
@@ -6,29 +5,28 @@ const { PasswordResetUuid, User } = model
 export const handlePasswordResetRequest = (req, res) => {
   const { email } = req.body
 
-  User.findOne({ where: { email } })
+  return User.findOne({ where: { email } })
     .then(user => {
-      const uuid = uuidv4()
-      PasswordResetUuid.create({ uuid, userId: user.id }).catch(err => {
-        // eslint-disable-next-line no-console
-        console.log(
-          'Something went wrong while creating database entry for new password reset token'
-        )
-        return res.status(500).send({
-          success: false,
-          message: 'Cannot create database entry',
-          error: err,
+      return PasswordResetUuid.create({ userId: user.id })
+        .then(() => {
+          // eslint-disable-next-line no-console
+          console.log('Created new database entry with uuid4 token')
+          return res.status(201).send({
+            success: true,
+            message: 'Email found and uuid generated and stored',
+          })
         })
-      })
-
-      // eslint-disable-next-line no-console
-      console.log('Created new database entry with uuid4 token')
-      // eslint-disable-next-line no-console
-      console.log(uuid)
-      return res.status(201).send({
-        success: true,
-        message: 'Email found and uuid generated and stored',
-      })
+        .catch(err => {
+          // eslint-disable-next-line no-console
+          console.log(
+            'Something went wrong while creating database entry for new password reset token'
+          )
+          return res.status(500).send({
+            success: false,
+            message: 'Cannot create database entry',
+            error: err,
+          })
+        })
     })
     .catch(err => {
       return res.status(500).send({

--- a/node/database/migrations/20190912080628-create-password-reset-uuids.js
+++ b/node/database/migrations/20190912080628-create-password-reset-uuids.js
@@ -1,0 +1,32 @@
+/* eslint-disable */
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('PasswordResetUuids', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      uuid: {
+        allowNull: false,
+        type: Sequelize.STRING
+      },
+      userId: {
+        allowNull: false,
+        type: Sequelize.INTEGER,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('PasswordResetUuids');
+  }
+};

--- a/node/models/passwordresetuuid.js
+++ b/node/models/passwordresetuuid.js
@@ -1,0 +1,17 @@
+module.exports = (sequelize, DataTypes) => {
+  const PasswordResetUuid = sequelize.define(
+    'PasswordResetUuid',
+    {
+      uuid: DataTypes.STRING,
+      userId: DataTypes.INTEGER,
+    },
+    {}
+  )
+  PasswordResetUuid.associate = models => {
+    PasswordResetUuid.belongsTo(models.User, {
+      foreignKey: 'userId',
+    })
+  }
+
+  return PasswordResetUuid
+}

--- a/node/models/passwordresetuuid.js
+++ b/node/models/passwordresetuuid.js
@@ -1,9 +1,21 @@
+import uuidv4 from 'uuid/v4'
+
 module.exports = (sequelize, DataTypes) => {
   const PasswordResetUuid = sequelize.define(
     'PasswordResetUuid',
     {
-      uuid: DataTypes.STRING,
-      userId: DataTypes.INTEGER,
+      uuid: {
+        type: DataTypes.UUIDV4,
+        allowNull: false,
+        unique: true,
+        defaultValue: () => {
+          return uuidv4()
+        },
+      },
+      userId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
     },
     {}
   )

--- a/node/models/user.js
+++ b/node/models/user.js
@@ -10,7 +10,7 @@ export default (sequelize, DataTypes) => {
         },
         unique: {
           args: true,
-          msg: 'Email already exists',
+          msg: 'Username already exists',
         },
       },
       email: {

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -6074,9 +6074,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
     "v8flags": {
       "version": "3.1.2",

--- a/node/package.json
+++ b/node/package.json
@@ -29,7 +29,8 @@
     "pg-hstore": "^2.3.2",
     "request": "^2.88.0",
     "request-promise": "^4.2.4",
-    "sequelize": "^5.2.15"
+    "sequelize": "^5.2.15",
+    "uuid": "^3.3.3"
   },
   "devDependencies": {
     "@babel/core": "7.4.3",

--- a/node/routes/index.js
+++ b/node/routes/index.js
@@ -8,6 +8,7 @@ import user from './user'
 import userInterest from './userInterest'
 import userQuestion from './userQuestion'
 import auth from './auth'
+import passwordReset from './passwordreset'
 
 const router = express.Router()
 
@@ -20,5 +21,6 @@ router.use('/user', user)
 router.use('/userInterest', userInterest)
 router.use('/userQuestion', userQuestion)
 router.use('/auth', auth)
+router.use('/passwordReset', passwordReset)
 
 export default router

--- a/node/routes/passwordreset/index.js
+++ b/node/routes/passwordreset/index.js
@@ -4,5 +4,6 @@ import * as passwordResetCtrl from '../../controllers/passwordreset'
 const router = express.Router()
 
 router.post('/', passwordResetCtrl.handlePasswordResetRequest)
+router.patch('/', passwordResetCtrl.handlePasswordReset)
 
 export default router

--- a/node/routes/passwordreset/index.js
+++ b/node/routes/passwordreset/index.js
@@ -1,0 +1,8 @@
+import express from 'express'
+import * as passwordResetCtrl from '../../controllers/passwordreset'
+
+const router = express.Router()
+
+router.post('/', passwordResetCtrl.handlePasswordResetRequest)
+
+export default router

--- a/npm-license-list.txt
+++ b/npm-license-list.txt
@@ -625,6 +625,12 @@
 │  ├─ url: http://github.com/mhart
 │  ├─ path: /usr/src/app/node_modules/aws4
 │  └─ licenseFile: /usr/src/app/node_modules/aws4/LICENSE
+├─ [34maxios[39m[2m@[22m[32m0.18.1[39m
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/axios/axios
+│  ├─ publisher: Matt Zabriskie
+│  ├─ path: /usr/src/app/node_modules/axios
+│  └─ licenseFile: /usr/src/app/node_modules/axios/LICENSE
 ├─ [34mbabel-eslint[39m[2m@[22m[32m10.0.1[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/babel/babel-eslint
@@ -632,13 +638,6 @@
 │  ├─ email: sebmck@gmail.com
 │  ├─ path: /usr/src/app/node_modules/babel-eslint
 │  └─ licenseFile: /usr/src/app/node_modules/babel-eslint/LICENSE
-├─ [34mbabel-runtime[39m[2m@[22m[32m6.26.0[39m
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-runtime
-│  ├─ publisher: Sebastian McKenzie
-│  ├─ email: sebmck@gmail.com
-│  ├─ path: /usr/src/app/node_modules/babel-runtime
-│  └─ licenseFile: /usr/src/app/node_modules/babel-runtime/README.md
 ├─ [34mbalanced-match[39m[2m@[22m[32m1.0.0[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/juliangruber/balanced-match
@@ -1076,6 +1075,13 @@
 │  ├─ email: tj@vision-media.ca
 │  ├─ path: /usr/src/app/node_modules/debug
 │  └─ licenseFile: /usr/src/app/node_modules/debug/LICENSE
+├─ [34mdebug[39m[2m@[22m[32m3.1.0[39m
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/visionmedia/debug
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ path: /usr/src/app/node_modules/follow-redirects/node_modules/debug
+│  └─ licenseFile: /usr/src/app/node_modules/follow-redirects/node_modules/debug/LICENSE
 ├─ [34mdebug[39m[2m@[22m[32m3.2.6[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/visionmedia/debug
@@ -1088,8 +1094,8 @@
 │  ├─ repository: https://github.com/visionmedia/debug
 │  ├─ publisher: TJ Holowaychuk
 │  ├─ email: tj@vision-media.ca
-│  ├─ path: /usr/src/app/node_modules/sequelize/node_modules/debug
-│  └─ licenseFile: /usr/src/app/node_modules/sequelize/node_modules/debug/LICENSE
+│  ├─ path: /usr/src/app/node_modules/needle/node_modules/debug
+│  └─ licenseFile: /usr/src/app/node_modules/needle/node_modules/debug/LICENSE
 ├─ [34mdecode-uri-component[39m[2m@[22m[32m0.2.0[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/SamVerschueren/decode-uri-component
@@ -1098,14 +1104,6 @@
 │  ├─ url: github.com/SamVerschueren
 │  ├─ path: /usr/src/app/node_modules/decode-uri-component
 │  └─ licenseFile: /usr/src/app/node_modules/decode-uri-component/license
-├─ [34mdeep-equal[39m[2m@[22m[32m1.0.1[39m
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/substack/node-deep-equal
-│  ├─ publisher: James Halliday
-│  ├─ email: mail@substack.net
-│  ├─ url: http://substack.net
-│  ├─ path: /usr/src/app/node_modules/deep-equal
-│  └─ licenseFile: /usr/src/app/node_modules/deep-equal/LICENSE
 ├─ [34mdeep-extend[39m[2m@[22m[32m0.6.0[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/unclechu/node-deep-extend
@@ -1264,12 +1262,6 @@
 │  ├─ repository: https://github.com/pillarjs/encodeurl
 │  ├─ path: /usr/src/app/node_modules/encodeurl
 │  └─ licenseFile: /usr/src/app/node_modules/encodeurl/LICENSE
-├─ [34mencoding[39m[2m@[22m[32m0.1.12[39m
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/andris9/encoding
-│  ├─ publisher: Andris Reinman
-│  ├─ path: /usr/src/app/node_modules/encoding
-│  └─ licenseFile: /usr/src/app/node_modules/encoding/LICENSE
 ├─ [34merror-ex[39m[2m@[22m[32m1.3.2[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/qix-/node-error-ex
@@ -1328,12 +1320,6 @@
 │  ├─ publisher: Ben Mosher
 │  ├─ email: me@benmosher.com
 │  └─ path: /usr/src/app/node_modules/eslint-module-utils
-├─ [34meslint-plugin-header[39m[2m@[22m[32m2.0.0[39m
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/Stuk/eslint-plugin-header
-│  ├─ publisher: Stuart Knightley
-│  ├─ path: /usr/src/app/node_modules/eslint-plugin-header
-│  └─ licenseFile: /usr/src/app/node_modules/eslint-plugin-header/README.md
 ├─ [34meslint-plugin-import[39m[2m@[22m[32m2.17.2[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/benmosher/eslint-plugin-import
@@ -1581,6 +1567,14 @@
 │  ├─ publisher: Andrea Giammarchi
 │  ├─ path: /usr/src/app/node_modules/flatted
 │  └─ licenseFile: /usr/src/app/node_modules/flatted/LICENSE
+├─ [34mfollow-redirects[39m[2m@[22m[32m1.5.10[39m
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/follow-redirects/follow-redirects
+│  ├─ publisher: Ruben Verborgh
+│  ├─ email: ruben@verborgh.org
+│  ├─ url: https://ruben.verborgh.org/
+│  ├─ path: /usr/src/app/node_modules/follow-redirects
+│  └─ licenseFile: /usr/src/app/node_modules/follow-redirects/LICENSE
 ├─ [34mfor-in[39m[2m@[22m[32m1.0.2[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/for-in
@@ -1698,12 +1692,6 @@
 │  ├─ email: alex.wilson@joyent.com
 │  ├─ path: /usr/src/app/node_modules/getpass
 │  └─ licenseFile: /usr/src/app/node_modules/getpass/LICENSE
-├─ [34mgfycat-sdk[39m[2m@[22m[32m1.4.18[39m
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/gfycat/gfycat-sdk
-│  ├─ publisher: Josh Kang, josh@gfycat.com
-│  ├─ path: /usr/src/app/node_modules/gfycat-sdk
-│  └─ licenseFile: /usr/src/app/node_modules/gfycat-sdk/LICENSE
 ├─ [34mglob-parent[39m[2m@[22m[32m3.1.0[39m
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/es128/glob-parent
@@ -1761,11 +1749,6 @@
 │  ├─ url: https://www.ahmadnassri.com/
 │  ├─ path: /usr/src/app/node_modules/har-validator
 │  └─ licenseFile: /usr/src/app/node_modules/har-validator/LICENSE
-├─ [34mharmony-reflect[39m[2m@[22m[32m1.6.1[39m
-│  ├─ licenses: (Apache-2.0 OR MPL-1.1)
-│  ├─ repository: git+https://tvcutsem@github.com/tvcutsem/harmony-reflect
-│  ├─ path: /usr/src/app/node_modules/harmony-reflect
-│  └─ licenseFile: /usr/src/app/node_modules/harmony-reflect/README.md
 ├─ [34mhas-flag[39m[2m@[22m[32m3.0.0[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/has-flag
@@ -2004,6 +1987,14 @@
 │  ├─ url: http://feross.org/
 │  ├─ path: /usr/src/app/node_modules/is-buffer
 │  └─ licenseFile: /usr/src/app/node_modules/is-buffer/LICENSE
+├─ [34mis-buffer[39m[2m@[22m[32m2.0.3[39m
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/feross/is-buffer
+│  ├─ publisher: Feross Aboukhadijeh
+│  ├─ email: feross@feross.org
+│  ├─ url: https://feross.org
+│  ├─ path: /usr/src/app/node_modules/axios/node_modules/is-buffer
+│  └─ licenseFile: /usr/src/app/node_modules/axios/node_modules/is-buffer/LICENSE
 ├─ [34mis-callable[39m[2m@[22m[32m1.1.4[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ljharb/is-callable
@@ -2246,13 +2237,6 @@
 │  ├─ url: https://github.com/jonschlinkert
 │  ├─ path: /usr/src/app/node_modules/isobject
 │  └─ licenseFile: /usr/src/app/node_modules/isobject/LICENSE
-├─ [34misomorphic-fetch[39m[2m@[22m[32m2.2.1[39m
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/matthew-andrews/isomorphic-fetch
-│  ├─ publisher: Matt Andrews
-│  ├─ email: matt@mattandre.ws
-│  ├─ path: /usr/src/app/node_modules/isomorphic-fetch
-│  └─ licenseFile: /usr/src/app/node_modules/isomorphic-fetch/LICENSE
 ├─ [34misstream[39m[2m@[22m[32m0.1.2[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/rvagg/isstream
@@ -2428,14 +2412,6 @@
 │  ├─ url: sindresorhus.com
 │  ├─ path: /usr/src/app/node_modules/locate-path
 │  └─ licenseFile: /usr/src/app/node_modules/locate-path/license
-├─ [34mlodash-es[39m[2m@[22m[32m4.17.11[39m
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/lodash/lodash
-│  ├─ publisher: John-David Dalton
-│  ├─ email: john.david.dalton@gmail.com
-│  ├─ url: http://allyoucanleet.com/
-│  ├─ path: /usr/src/app/node_modules/lodash-es
-│  └─ licenseFile: /usr/src/app/node_modules/lodash-es/LICENSE
 ├─ [34mlodash.includes[39m[2m@[22m[32m4.3.0[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/lodash/lodash
@@ -2552,12 +2528,6 @@
 │  ├─ url: https://github.com/jonschlinkert
 │  ├─ path: /usr/src/app/node_modules/map-visit
 │  └─ licenseFile: /usr/src/app/node_modules/map-visit/LICENSE
-├─ [34mmattermost-redux[39m[2m@[22m[32m5.10.0[39m
-│  ├─ licenses: Apache-2.0
-│  ├─ repository: https://github.com/mattermost/mattermost-redux
-│  ├─ path: /usr/src/app/node_modules/mattermost-redux
-│  ├─ licenseFile: /usr/src/app/node_modules/mattermost-redux/LICENSE.txt
-│  └─ noticeFile: /usr/src/app/node_modules/mattermost-redux/NOTICE.txt
 ├─ [34mmedia-typer[39m[2m@[22m[32m0.3.0[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jshttp/media-typer
@@ -2585,11 +2555,6 @@
 │  ├─ url: https://github.com/jonschlinkert
 │  ├─ path: /usr/src/app/node_modules/micromatch
 │  └─ licenseFile: /usr/src/app/node_modules/micromatch/LICENSE
-├─ [34mmime-db[39m[2m@[22m[32m1.37.0[39m
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jshttp/mime-db
-│  ├─ path: /usr/src/app/node_modules/mattermost-redux/node_modules/mime-db
-│  └─ licenseFile: /usr/src/app/node_modules/mattermost-redux/node_modules/mime-db/LICENSE
 ├─ [34mmime-db[39m[2m@[22m[32m1.40.0[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jshttp/mime-db
@@ -2700,8 +2665,8 @@
 ├─ [34mms[39m[2m@[22m[32m2.1.1[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/zeit/ms
-│  ├─ path: /usr/src/app/node_modules/nodemon/node_modules/ms
-│  └─ licenseFile: /usr/src/app/node_modules/nodemon/node_modules/ms/license.md
+│  ├─ path: /usr/src/app/node_modules/needle/node_modules/ms
+│  └─ licenseFile: /usr/src/app/node_modules/needle/node_modules/ms/license.md
 ├─ [34mmute-stream[39m[2m@[22m[32m0.0.7[39m
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/isaacs/mute-stream
@@ -2746,12 +2711,6 @@
 │  ├─ repository: https://github.com/electerious/nice-try
 │  ├─ path: /usr/src/app/node_modules/nice-try
 │  └─ licenseFile: /usr/src/app/node_modules/nice-try/LICENSE
-├─ [34mnode-fetch[39m[2m@[22m[32m1.7.3[39m
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/bitinn/node-fetch
-│  ├─ publisher: David Frank
-│  ├─ path: /usr/src/app/node_modules/node-fetch
-│  └─ licenseFile: /usr/src/app/node_modules/node-fetch/LICENSE.md
 ├─ [34mnode-modules-regexp[39m[2m@[22m[32m1.0.0[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jamestalmage/node-modules-regexp
@@ -3463,43 +3422,6 @@
 │  ├─ url: thlorenz.com
 │  ├─ path: /usr/src/app/node_modules/readdirp
 │  └─ licenseFile: /usr/src/app/node_modules/readdirp/LICENSE
-├─ [34mredux-action-buffer[39m[2m@[22m[32m1.2.0[39m
-│  ├─ licenses: MIT
-│  ├─ publisher: rt2zz
-│  ├─ email: zack@root-two.com
-│  ├─ path: /usr/src/app/node_modules/redux-action-buffer
-│  └─ licenseFile: /usr/src/app/node_modules/redux-action-buffer/LICENSE
-├─ [34mredux-batched-actions[39m[2m@[22m[32m0.4.1[39m
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/tshelburne/redux-batched-actions
-│  ├─ publisher: Tim Shelburne
-│  ├─ email: shelburt02@gmail.com
-│  ├─ path: /usr/src/app/node_modules/redux-batched-actions
-│  └─ licenseFile: /usr/src/app/node_modules/redux-batched-actions/LICENSE.txt
-├─ [34mredux-offline[39m[2m@[22m[32m1.1.5[39m
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jevakallio/redux-offline
-│  ├─ path: /usr/src/app/node_modules/redux-offline
-│  └─ licenseFile: /usr/src/app/node_modules/redux-offline/LICENSE
-├─ [34mredux-persist[39m[2m@[22m[32m4.9.1[39m
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/rt2zz/redux-persist
-│  ├─ publisher: rt2zz
-│  ├─ email: zack@root-two.com
-│  ├─ path: /usr/src/app/node_modules/redux-persist
-│  └─ licenseFile: /usr/src/app/node_modules/redux-persist/LICENSE.md
-├─ [34mredux-thunk[39m[2m@[22m[32m2.3.0[39m
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/reduxjs/redux-thunk
-│  ├─ publisher: Dan Abramov
-│  ├─ email: dan.abramov@me.com
-│  ├─ path: /usr/src/app/node_modules/redux-thunk
-│  └─ licenseFile: /usr/src/app/node_modules/redux-thunk/LICENSE.md
-├─ [34mredux[39m[2m@[22m[32m4.0.1[39m
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/reduxjs/redux
-│  ├─ path: /usr/src/app/node_modules/redux
-│  └─ licenseFile: /usr/src/app/node_modules/redux/LICENSE.md
 ├─ [34mregenerate-unicode-properties[39m[2m@[22m[32m8.0.2[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mathiasbynens/regenerate-unicode-properties
@@ -3514,13 +3436,6 @@
 │  ├─ url: https://mathiasbynens.be/
 │  ├─ path: /usr/src/app/node_modules/regenerate
 │  └─ licenseFile: /usr/src/app/node_modules/regenerate/LICENSE-MIT.txt
-├─ [34mregenerator-runtime[39m[2m@[22m[32m0.11.1[39m
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime
-│  ├─ publisher: Ben Newman
-│  ├─ email: bn@cs.stanford.edu
-│  ├─ path: /usr/src/app/node_modules/regenerator-runtime
-│  └─ licenseFile: /usr/src/app/node_modules/regenerator-runtime/README.md
 ├─ [34mregenerator-runtime[39m[2m@[22m[32m0.13.2[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime
@@ -3611,6 +3526,20 @@
 │  ├─ url: http://github.com/jonschlinkert
 │  ├─ path: /usr/src/app/node_modules/repeat-string
 │  └─ licenseFile: /usr/src/app/node_modules/repeat-string/LICENSE
+├─ [34mrequest-promise-core[39m[2m@[22m[32m1.1.2[39m
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/request/promise-core
+│  ├─ publisher: Nicolai Kamenzky
+│  ├─ url: https://github.com/analog-nico
+│  ├─ path: /usr/src/app/node_modules/request-promise-core
+│  └─ licenseFile: /usr/src/app/node_modules/request-promise-core/LICENSE
+├─ [34mrequest-promise[39m[2m@[22m[32m4.2.4[39m
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/request/request-promise
+│  ├─ publisher: Nicolai Kamenzky
+│  ├─ url: https://github.com/analog-nico
+│  ├─ path: /usr/src/app/node_modules/request-promise
+│  └─ licenseFile: /usr/src/app/node_modules/request-promise/LICENSE
 ├─ [34mrequest[39m[2m@[22m[32m2.88.0[39m
 │  ├─ licenses: Apache-2.0
 │  ├─ repository: https://github.com/request/request
@@ -3618,11 +3547,6 @@
 │  ├─ email: mikeal.rogers@gmail.com
 │  ├─ path: /usr/src/app/node_modules/request
 │  └─ licenseFile: /usr/src/app/node_modules/request/LICENSE
-├─ [34mreselect[39m[2m@[22m[32m4.0.0[39m
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/reduxjs/reselect
-│  ├─ path: /usr/src/app/node_modules/reselect
-│  └─ licenseFile: /usr/src/app/node_modules/reselect/LICENSE
 ├─ [34mresolve-from[39m[2m@[22m[32m4.0.0[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/resolve-from
@@ -3765,14 +3689,6 @@
 │  ├─ email: sascha@depold.com
 │  ├─ path: /usr/src/app/node_modules/sequelize
 │  └─ licenseFile: /usr/src/app/node_modules/sequelize/LICENSE
-├─ [34mserialize-error[39m[2m@[22m[32m2.1.0[39m
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/sindresorhus/serialize-error
-│  ├─ publisher: Sindre Sorhus
-│  ├─ email: sindresorhus@gmail.com
-│  ├─ url: sindresorhus.com
-│  ├─ path: /usr/src/app/node_modules/serialize-error
-│  └─ licenseFile: /usr/src/app/node_modules/serialize-error/license
 ├─ [34mserve-static[39m[2m@[22m[32m1.13.2[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/expressjs/serve-static
@@ -3807,14 +3723,6 @@
 │  ├─ publisher: Wes Todd
 │  ├─ path: /usr/src/app/node_modules/setprototypeof
 │  └─ licenseFile: /usr/src/app/node_modules/setprototypeof/LICENSE
-├─ [34mshallow-equals[39m[2m@[22m[32m1.0.0[39m
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/hughsk/shallow-equals
-│  ├─ publisher: Hugh Kennedy
-│  ├─ email: hughskennedy@gmail.com
-│  ├─ url: http://hughsk.io/
-│  ├─ path: /usr/src/app/node_modules/shallow-equals
-│  └─ licenseFile: /usr/src/app/node_modules/shallow-equals/LICENSE.md
 ├─ [34mshebang-command[39m[2m@[22m[32m1.2.0[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/kevva/shebang-command
@@ -3985,6 +3893,13 @@
 │  ├─ repository: https://github.com/jshttp/statuses
 │  ├─ path: /usr/src/app/node_modules/statuses
 │  └─ licenseFile: /usr/src/app/node_modules/statuses/LICENSE
+├─ [34mstealthy-require[39m[2m@[22m[32m1.1.1[39m
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/analog-nico/stealthy-require
+│  ├─ publisher: Nicolai Kamenzky
+│  ├─ url: https://github.com/analog-nico
+│  ├─ path: /usr/src/app/node_modules/stealthy-require
+│  └─ licenseFile: /usr/src/app/node_modules/stealthy-require/LICENSE
 ├─ [34mstring-width[39m[2m@[22m[32m1.0.2[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/string-width
@@ -4070,13 +3985,6 @@
 │  ├─ url: sindresorhus.com
 │  ├─ path: /usr/src/app/node_modules/supports-color
 │  └─ licenseFile: /usr/src/app/node_modules/supports-color/license
-├─ [34msymbol-observable[39m[2m@[22m[32m1.2.0[39m
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/blesh/symbol-observable
-│  ├─ publisher: Ben Lesh
-│  ├─ email: ben@benlesh.com
-│  ├─ path: /usr/src/app/node_modules/symbol-observable
-│  └─ licenseFile: /usr/src/app/node_modules/symbol-observable/license
 ├─ [34mtable[39m[2m@[22m[32m5.2.3[39m
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/gajus/table
@@ -4355,7 +4263,7 @@
 │  ├─ url: http://www.jaredhanson.net/
 │  ├─ path: /usr/src/app/node_modules/utils-merge
 │  └─ licenseFile: /usr/src/app/node_modules/utils-merge/LICENSE
-├─ [34muuid[39m[2m@[22m[32m3.3.2[39m
+├─ [34muuid[39m[2m@[22m[32m3.3.3[39m
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/kelektiv/node-uuid
 │  ├─ path: /usr/src/app/node_modules/uuid
@@ -4395,11 +4303,6 @@
 │  ├─ repository: https://github.com/davepacheco/node-verror
 │  ├─ path: /usr/src/app/node_modules/verror
 │  └─ licenseFile: /usr/src/app/node_modules/verror/LICENSE
-├─ [34mwhatwg-fetch[39m[2m@[22m[32m3.0.0[39m
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/github/fetch
-│  ├─ path: /usr/src/app/node_modules/whatwg-fetch
-│  └─ licenseFile: /usr/src/app/node_modules/whatwg-fetch/LICENSE
 ├─ [34mwhich[39m[2m@[22m[32m1.3.1[39m
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/isaacs/node-which


### PR DESCRIPTION
Reset password link for user #80

Added migration and model for database table "passwordResetUuids", that contain a reference to a user, and a string column that contains the uuidv4 token. The base "createdAt" can be used to check if the token is still fresh enough to be actually used to reset a password.

Also added new controller that can handle requests to add a new token, the method requires an email component in the req -object and if the user is found, adds a new token in the database and prints it in the console. 

Obviously, also added a router with a path to this controller, the current path set is /passwordReset with post.

Also added a template for handling a password reset, currently it answers to /passwordReset patch requests, but all it does is report if the given uuid is in the database and is found, does not actually change password or anything else (can be used as template when adding this functionality saving 30min from the guy doing it)

