### PR TITLE
Delete user flow

### DIFF
--- a/node/controllers/user/index.js
+++ b/node/controllers/user/index.js
@@ -30,6 +30,8 @@ export const getUser = (req, res) => {
     .then(user => {
       const {
         nickname,
+        first_name,
+        last_name,
         location,
         description,
         birthdate,
@@ -42,6 +44,8 @@ export const getUser = (req, res) => {
       } = user
       res.status(200).send({
         nickname,
+        first_name,
+        last_name,
         location,
         description,
         birthdate,
@@ -135,6 +139,8 @@ export const addUser = async (req, res) => {
     username,
     email,
     password: hashed,
+    first_name,
+    last_name,
     birthdate,
     phoneNumber,
     nickname,
@@ -230,6 +236,8 @@ export const updateUser = (req, res) => {
   const {
     username,
     email,
+    first_name,
+    last_name,
     nickname,
     location,
     description,
@@ -254,6 +262,8 @@ export const updateUser = (req, res) => {
         username,
         email,
         nickname,
+        first_name,
+        last_name,
         location,
         description,
         profileReady,

--- a/node/controllers/user/index.js
+++ b/node/controllers/user/index.js
@@ -160,7 +160,7 @@ export const addUser = async (req, res) => {
       })
       return [results, results2]
     })
-    .catch(err => {
+    .catch(async err => {
       // If there was some problem while creating mattermost user,
       // delete related node user and rollback
       await User.destroy({

--- a/node/controllers/user/index.js
+++ b/node/controllers/user/index.js
@@ -141,45 +141,42 @@ export const addUser = async (req, res) => {
     showLocation,
   }
   try {
+    // create node-user
     const nodeUser = await User.create(user)
-    if (nodeUser) {
-      // Create mmuser if nodeuser was created
-      const mmresp = await axios.post(`${mattermostUrl}/users`, {
-        username,
-        email,
-        password,
-        first_name,
-        last_name,
-        nickname,
-      })
-      if (mmresp && nodeUser) {
-        // If both we created successfully, add user to team
-        const mmuser = mmresp.data
-        axios.defaults.headers.common.Authorization = `Bearer ${process.env.MASTER_TOKEN}`
-        const mmTeamResp = await axios.post(
-          `${mattermostUrl}/teams/${process.env.TEAM_ID}/members`,
-          {
-            team_id: process.env.TEAM_ID,
-            user_id: mmuser.id,
-          }
-        )
-        const team = mmTeamResp.data
-        // Send created response
-        res.status(201).send({
-          success: true,
-          message: 'User successfully created',
-          results: {
-            username: nodeUser.username,
-            email: nodeUser.email,
-            nickname: nodeUser.nickname,
-            birthdate: nodeUser.birthdate,
-            phoneNumber: nodeUser.phoneNumber,
-          },
-          mmuser,
-          team,
-        })
+    // Create mmuser
+    const mmresp = await axios.post(`${mattermostUrl}/users`, {
+      username,
+      email,
+      password,
+      first_name,
+      last_name,
+      nickname,
+    })
+    // Add user to team
+    const mmuser = mmresp.data
+    axios.defaults.headers.common.Authorization = `Bearer ${process.env.MASTER_TOKEN}`
+    const mmTeamResp = await axios.post(
+      `${mattermostUrl}/teams/${process.env.TEAM_ID}/members`,
+      {
+        team_id: process.env.TEAM_ID,
+        user_id: mmuser.id,
       }
-    }
+    )
+    const team = mmTeamResp.data
+    // Send created response
+    res.status(201).send({
+      success: true,
+      message: 'User successfully created',
+      results: {
+        username: nodeUser.username,
+        email: nodeUser.email,
+        nickname: nodeUser.nickname,
+        birthdate: nodeUser.birthdate,
+        phoneNumber: nodeUser.phoneNumber,
+      },
+      mmuser,
+      team,
+    })
   } catch (e) {
     if (e && e.name == 'SequelizeUniqueConstraintError') {
       // There was problem while creating node-user

--- a/node/database/migrations/20200121142149-add-deleteAt-to-user.js
+++ b/node/database/migrations/20200121142149-add-deleteAt-to-user.js
@@ -1,0 +1,11 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('Users', 'deleteAt', Sequelize.DATE)
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('Users', 'deleteAt', Sequelize.DATE)
+  },
+}

--- a/node/database/migrations/20200122091055-add-firstname-lastname-to-user.js
+++ b/node/database/migrations/20200122091055-add-firstname-lastname-to-user.js
@@ -1,0 +1,23 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface
+      .addColumn('Users', 'first_name', Sequelize.STRING)
+      .then(() => {
+        return queryInterface.addColumn('Users', 'last_name', Sequelize.STRING)
+      })
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface
+      .removeColumn('Users', 'first_name', Sequelize.STRING)
+      .then(() => {
+        return queryInterface.removeColumn(
+          'Users',
+          'last_name',
+          Sequelize.STRING
+        )
+      })
+  },
+}

--- a/node/models/user.js
+++ b/node/models/user.js
@@ -80,6 +80,9 @@ export default (sequelize, DataTypes) => {
         },
         defaultValue: false,
       },
+      deleteAt: {
+        type: DataTypes.DATE,
+      },
     },
     {}
   )

--- a/node/models/user.js
+++ b/node/models/user.js
@@ -44,6 +44,14 @@ export default (sequelize, DataTypes) => {
         type: DataTypes.STRING,
         allowNull: true,
       },
+      first_name: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+      last_name: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
       description: {
         type: DataTypes.STRING,
         allowNull: true,

--- a/node/routes/user/index.js
+++ b/node/routes/user/index.js
@@ -20,4 +20,16 @@ router.patch('/:id', passport.authenticate('jwt'), userCtrl.updateUser)
 
 router.delete('/:id', passport.authenticate('jwt'), userCtrl.deleteUser)
 
+router.delete(
+  '/deletenow/:id',
+  passport.authenticate('jwt'),
+  userCtrl.deleteUserImmediately
+)
+
+router.post(
+  '/restore/:id',
+  passport.authenticate('jwt'),
+  userCtrl.abortDeleteUser
+)
+
 export default router


### PR DESCRIPTION
Adds mattermost user deactivation to delete user api. Also adds some improvements to user creation flow to handle errors happening in different stages in a different manner.

Delete user flow:
1) Add timestamp to user field `deleteAt`. These are used to automatically remove users in cron job / bash script / what ever suitable in production environment. No changes to mattermost-user yet.
2) User can still be  re-activated and this removes the `deleteAt` timestamp.
3) If relevant, user can be removed permanently calling deleteUserImmediately, like so:

Delete user immediately flow:
1) Update user email to something random so that it can be used again for different user
2) Deactivate mattermost user (it cannot be completely deleted)
3) If these steps are successful then delete also node-user

User creation:
The most important change is that if mattermost user creation fails, already created node-user is deleted to avoid ghost users blocking registering.