### PR TITLE
backend/dbDockerfileFix

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:9.4-alpine
+FROM postgres:9.4.24-alpine
 
 ENV DEFAULT_TIMEZONE UTC
 


### PR DESCRIPTION
The new version of base image used in db/Dockerfile does not work if build from, this version does.