### PR TITLE
Check if password reset link has been used

### DIFF
--- a/node/controllers/auth/index.js
+++ b/node/controllers/auth/index.js
@@ -76,16 +76,14 @@ export const forgot = async (req, res) => {
   try {
     const user = await User.findOne({ where: { email } })
     if (!user) {
-      res.status(400).send({
+      return res.status(400).send({
         success: false,
         message: 'Could not find account with that email',
       })
     }
     const createdToken = await PasswordResetUuid.create({ userId: user.id })
     const emailToSend = `<p>Hei!</p>
-    <p><a href="${process.env.FRONTEND_URL}/reset-password/${
-      createdToken.uuid
-    }/">Tästä linkistä</a> pääset vaihtamaan salasanasi Kohdataan-palveluun.</p>
+    <p><a href="${process.env.FRONTEND_URL}/reset-password/${createdToken.uuid}/">Tästä linkistä</a> pääset vaihtamaan salasanasi Kohdataan-palveluun.</p>
     <p>Jos tarvitset apua salasanan vaihtamisessa, vastaa tähän sähköpostiin ja kerro lisää.</p>
     <p>Jos et ole pyytänyt salasanan palautusta, sinun ei tarvitse tehdä mitään.</p>
     <p>Voit kuitenkin aina ottaa meihin yhteyttä, jos epäilet, että sähköpostiasi käytetään väärin.</p>
@@ -209,7 +207,7 @@ export const checkIfResetUsed = async (req, res) => {
       where: { uuid },
     })
     if (!passwordResetEntry) {
-      res.status(400).send({
+      return res.status(400).send({
         success: false,
         message: 'Could not find password reset entry with given uuid',
       })

--- a/node/routes/auth/index.js
+++ b/node/routes/auth/index.js
@@ -12,6 +12,8 @@ router.post('/forgot', authCtrl.forgot)
 
 router.post('/reset', authCtrl.reset)
 
+router.post('/check-resetlink', authCtrl.checkIfResetUsed)
+
 router.post('/update-password', authCtrl.updatePassword)
 
 export default router


### PR DESCRIPTION
Adds a check for if password reset link has been used prior to filling in the form. A separate check was necessary because desired behaviour was for the link to redirect straight to login and give a notification if the link had already been used. 